### PR TITLE
As long as the job icon is red or red-running, make status as failed.

### DIFF
--- a/lib/lita/handlers/github_pr.rb
+++ b/lib/lita/handlers/github_pr.rb
@@ -360,10 +360,10 @@ module Lita
         case color
         when 'blue'
           return 'passing'
-        when /[a-z]+_anime/
-          return 'running'
-        else
+        when 'red'
           return 'fail'
+        else
+          return 'running'
         end
       end
 

--- a/lib/lita/handlers/github_pr.rb
+++ b/lib/lita/handlers/github_pr.rb
@@ -360,7 +360,7 @@ module Lita
         case color
         when 'blue'
           return 'passing'
-        when 'red'
+        when 'red','red_anime'
           return 'fail'
         else
           return 'running'

--- a/lib/lita/handlers/github_pr.rb
+++ b/lib/lita/handlers/github_pr.rb
@@ -360,7 +360,7 @@ module Lita
         case color
         when 'blue'
           return 'passing'
-        when 'red','red_anime'
+        when 'red','red_anime','aborted'
           return 'fail'
         else
           return 'running'


### PR DESCRIPTION
Also, check for running only after checking for passing and failing.
We are ignoring "aborted"...can check for that if we know what to do with it.
