### PR TITLE
Support checking/merging of review-check-only PR based on git-repo 

### DIFF
--- a/lib/lita/handlers/github_pr.rb
+++ b/lib/lita/handlers/github_pr.rb
@@ -325,7 +325,7 @@ module Lita
           end
           r << ")"
         end
-        r << "|\n"
+        r << " |\n"
         r << "| Master open for merge: #{p[:jenkins]}"
         if p[:jenkins] == false
           r << " ("
@@ -334,7 +334,7 @@ module Lita
           end
           r << ")"
         end
-        r << "|\n"
+        r << " |\n"
         response.reply(r)
       end
 

--- a/lib/lita/handlers/github_pr.rb
+++ b/lib/lita/handlers/github_pr.rb
@@ -306,18 +306,18 @@ module Lita
 
       def pr_show_state(response)
         p = self.class.pr_state
-        r = "PR #{p[:id]}\n"
-        r << "#{p[:url]}\n"
-        r << "| Already merged: #{p[:merged]} |\n"
-        r << "| Reviewed: #{p[:review]} by #{p[:reviewer]} |\n"
+        r = "PR #{p[:id]} \n"
+        r << "#{p[:url]} \n"
+        r << "Already merged: #{p[:merged]} \n"
+        r << "Reviewed: #{p[:review]} by #{p[:reviewer]} \n"
 
         # Check if git repo is check-review only. Return if so.
         if pr_review_check_only?(response)
            return response.reply(r)
         end
 
-        r << "| Passed CI: #{p[:test]} |\n"
-        r << "| Passed long_system_test: #{p[:jenkins_lst]}"
+        r << "Passed CI: #{p[:test]} \n"
+        r << "Passed long_system_test: #{p[:jenkins_lst]} "
         if p[:jenkins_lst] == false
           r << " ("
           p[:lst_jobs].each do |name, result|
@@ -325,8 +325,8 @@ module Lita
           end
           r << ")"
         end
-        r << " |\n"
-        r << "| Master open for merge: #{p[:jenkins]}"
+        r << " \n"
+        r << "Master open for merge: #{p[:jenkins]} "
         if p[:jenkins] == false
           r << " ("
           p[:jobs].each do |name, result|
@@ -334,7 +334,7 @@ module Lita
           end
           r << ")"
         end
-        r << " |\n"
+        r << " \n"
         response.reply(r)
       end
 

--- a/lib/lita/handlers/github_pr.rb
+++ b/lib/lita/handlers/github_pr.rb
@@ -323,16 +323,18 @@ module Lita
           p[:lst_jobs].each do |name, result|
             r << "#{result}"
           end
-          r << ") |\n"
+          r << ")"
         end
+        r << "|\n"
         r << "| Master open for merge: #{p[:jenkins]}"
         if p[:jenkins] == false
           r << " ("
           p[:jobs].each do |name, result|
             r << "#{result}"
           end
-          r << ") |\n"
+          r << ")"
         end
+        r << "|\n"
         response.reply(r)
       end
 


### PR DESCRIPTION
This PR goes along with PR from fdsbot to add a config in
_check_review_status_only_repos_

It adds new method _pr_review_check_only?_ that will check if PR is from the repos configured in fdsbot.
The new method is called from other places to determine if passing checks and what to display when showing PR status.

The _show_state_ method is also been modified to display the following format
**PR 42
http://url/pr42
Already merged: false
Reviewed:  true by Po
Passed CI: false
Passed long_system_test: false (failed)
Master open for merge: true**

If the git-repo is listed in the _check_review_status_only_repos_,  the _show_state_ method will only list the  **Reviewed** field.
